### PR TITLE
Update README.txt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,17 +20,12 @@ Installation Steps
 
     plugin_dirs = '/usr/lib/python2.7/site-packages/avi/heat'
 
-3. Provide the IP address or FQDN for the Avi Controller. Use one of the following options:
-
-   OPTION 1: In heat.conf
-     Update your /etc/heat/heat.conf and add the following in the [Default] section:
+3. Provide the IP address or FQDN for the Avi Controller. Update your 
+/etc/heat/heat.conf and add the following in the [Default] section:
 
    ::
 
        avi_controller = '10.10.25.200'
-
-   OPTION 2: Via avi-lbaas service in keystone catalog
-     Please refer to Avi Knowledge Brief at https://avinetworks.com/docs/18.2/installing-the-lbaas-driver-cli-shell-openstack/#adding-a-keystone-catalog-entry-for-avi-vantage for details on how to define avi-lbaas service and an endpoint for it in your keystone catalog.
 
 
 4. Restart heat-engine after adding this. For example::


### PR DESCRIPTION
Remove option to give Avi Controller IP by creating an endpoint in OpenStack.
Mechanism to search for endpoints in OpenStack might change over time and
new releases of OpenStack - we don't want to add that dependency.